### PR TITLE
[feat] : useremail api permission_classes 삭제

### DIFF
--- a/apps/gmail/views.py
+++ b/apps/gmail/views.py
@@ -11,8 +11,6 @@ FROM_EMAIL = settings.base.EMAIL_HOST_USER
 
 
 class UserEmail(APIView):
-    permission_classes = [IsAuthenticated]
-
     def get(self, request, *args, **kwargs):
         """
         slug로 대상 email 및 정보 조회


### PR DESCRIPTION


## <useremail api permission_classes 삭제>

- what : useremail api permission_classes 삭제
- why : 로그인 하지 않은 사용자도 볼 수 있도록

## 병합 전 체크리스트

- [x] 구현한 기능 테스트
- [x] 모델을 수정, 생성한 뒤 migrations 파일을 생성
- [x] 린팅 도구에서 표시된 오류를 해결 ( flake8 )
- [x] 포매팅 도구를 사용해 코드를 정리 ( black )
